### PR TITLE
Harden no-tool mode prompts and add regression tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# Repository Development Guidelines
+
+- Suivez PEP 8 et utilisez systématiquement les annotations de types Python.
+- Aucune dépendance externe supplémentaire ne doit être ajoutée sans justification explicite.
+- Préférez les fonctions utilitaires existantes d'Open WebUI documentées dans `docs_openwebui/`.
+- Les nouveaux champs ou options doivent être documentés dans le `README.md` correspondant.
+- Maintenez une journalisation cohérente via le logger défini dans `planner.py`.
+- Évitez toute logique spécifique à un environnement particulier : le code doit rester générique.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ This powerful agent autonomously generates and executes multi-step plans to achi
 - `ACTION_TIMEOUT` (300): Individual action timeout
 - `SHOW_ACTION_SUMMARIES` (true): Detailed execution summaries
 - `AUTOMATIC_TAKS_REQUIREMENT_ENHANCEMENT` (false): AI-enhanced requirements
+- `ENABLE_TOOL_INTEGRATION` (true): Enable automatic tool discovery, usage, scoring impact, and prompt adaptations. Set to `false` to completely ignore Open WebUI tools.
+
+**Testing:**
+
+- `python -m compileall planner.py`: quick syntax verification
+- `python planner.py`: runs the built-in no-tool-mode regression tests (uses lightweight stubs, no Open WebUI instance required)
 
 ### 💡 Usage Examples
 


### PR DESCRIPTION
## Summary
- isolate lightweight-context metadata formatting and prompts so they avoid tool guidance when integration is disabled
- short-circuit lightweight context optimization when tools are off and provide Open WebUI stubs to allow local regression tests
- add an inline no-tool regression test suite and document the testing commands in the README

## Testing
- python -m compileall planner.py
- python planner.py

------
https://chatgpt.com/codex/tasks/task_e_68e16dfcb2d88327bc0d1d09343b807c