### PR TITLE
Disable temperature parameter for ChatGPT-5 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,7 @@ This powerful agent autonomously generates and executes multi-step plans to achi
 - `WRITER_MODEL`: Creative writing and documentation
 - `CODER_MODEL`: Code generation and development
 
-**Temperature Controls:**
-
-- `PLANNING_TEMPERATURE` (0.8): Planning creativity
-- `ACTION_TEMPERATURE` (0.7): Tool execution precision
-- `WRITER_TEMPERATURE` (0.9): Creative writing freedom
-- `CODER_TEMPERATURE` (0.3): Code generation accuracy
-- `ANALYSIS_TEMPERATURE` (0.4): Output analysis precision
+**Temperature Controls:** Disabled. The ChatGPT-5 backend used by this planner no longer accepts a `temperature` parameter, so all related configuration knobs have been removed to prevent unsupported settings from being surfaced.
 
 **Execution Settings:**
 

--- a/tests/test_plan_structure_section.py
+++ b/tests/test_plan_structure_section.py
@@ -17,7 +17,6 @@ class PipeForPlanStructureTest(Pipe):
     async def get_completion(  # type: ignore[override]
         self,
         prompt,
-        temperature: float = 0.7,
         model: str | dict[str, object] = "",
         tools: dict[str, dict[object, object]] | None = None,
         format: dict[str, object] | None = None,

--- a/tests/test_temperature_disabled.py
+++ b/tests/test_temperature_disabled.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from planner import Pipe, Request, Users
+
+
+def test_get_completion_omits_temperature_parameter(monkeypatch: pytest.MonkeyPatch) -> None:
+    pipe = Pipe()
+    pipe.__request__ = Request()  # type: ignore[attr-defined]
+    pipe.__user__ = Users.get_user_by_id("stub")  # type: ignore[attr-defined]
+
+    captured_payload: dict[str, Any] = {}
+
+    async def fake_generate_chat_completion(_request: Any, payload: dict[str, Any], **_kwargs: Any) -> dict[str, Any]:
+        nonlocal captured_payload
+        captured_payload = payload
+        return {"choices": [{"message": {"content": ""}}]}
+
+    monkeypatch.setattr("planner.generate_chat_completion", fake_generate_chat_completion)
+
+    asyncio.run(pipe.get_completion("hello"))
+
+    assert "temperature" not in captured_payload
+
+
+def test_temperature_valves_are_unavailable() -> None:
+    pipe = Pipe()
+
+    for field_name in [
+        "ACTION_TEMPERATURE",
+        "WRITER_TEMPERATURE",
+        "CODER_TEMPERATURE",
+        "PLANNING_TEMPERATURE",
+        "ANALYSIS_TEMPERATURE",
+    ]:
+        assert not hasattr(pipe.valves, field_name)


### PR DESCRIPTION
## Summary
- remove temperature-related configuration from the planner and stop including the parameter when building LLM requests
- add regression tests verifying the parameter is neither exposed in valves nor sent to the chat completion helper
- update configuration docs to explain that temperature controls are disabled for the ChatGPT-5 backend

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e1953d98f48327962bb5e7fbedacec