### PR TITLE
Improve design review summaries and enforce language guidance

### DIFF
--- a/planner.py
+++ b/planner.py
@@ -933,7 +933,8 @@ WORKING GUIDELINES:
         return textwrap.dedent(
             """
             LANGUAGE CONSISTENCY:
-            - Unless the overall goal or this step explicitly requires another language, respond entirely in the same language as the user's request and step description.
+            - Match the language of the initial user prompt unless that prompt explicitly instructs you to respond in another language.
+            - If the user specifies a response language, follow that instruction exactly.
             - Do not mix multiple languages within the same response.
 
             FORMATTING STANDARD:

--- a/tests/test_action_prompt_language_markdown.py
+++ b/tests/test_action_prompt_language_markdown.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from planner import Action, Plan, Pipe
+
+
+class CapturingPipe(Pipe):
+    def __init__(self) -> None:
+        super().__init__()
+
+
+def test_action_prompt_enforces_language_and_markdown() -> None:
+    plan = Plan(
+        goal="Créer cinq invites",  # French goal triggers French requirement
+        actions=[
+            Action(
+                id="step1",
+                type="text",
+                description="Rédiger un prompt pour un mammifère spécifique",
+            ),
+        ],
+    )
+
+    pipe = CapturingPipe()
+
+    prompt = pipe._build_full_context_prompt(
+        plan=plan,
+        action=plan.actions[0],
+        step_number=1,
+        context_for_prompt={},
+        requirements=pipe.valves.ACTION_PROMPT_REQUIREMENTS_TEMPLATE,
+        user_guidance_text="",
+    )
+
+    assert "LANGUAGE CONSISTENCY" in prompt
+    assert "same language" in prompt
+    assert "Format the whole response using Markdown" in prompt
+
+    lightweight_prompt = pipe._build_lightweight_prompt(
+        plan=plan,
+        action=plan.actions[0],
+        step_number=1,
+        context_metadata={},
+        requirements=pipe.valves.ACTION_PROMPT_REQUIREMENTS_TEMPLATE,
+        user_guidance_text="",
+    )
+
+    assert "LANGUAGE CONSISTENCY" in lightweight_prompt
+    assert "Markdown" in lightweight_prompt

--- a/tests/test_action_prompt_language_markdown.py
+++ b/tests/test_action_prompt_language_markdown.py
@@ -35,7 +35,8 @@ def test_action_prompt_enforces_language_and_markdown() -> None:
     )
 
     assert "LANGUAGE CONSISTENCY" in prompt
-    assert "same language" in prompt
+    assert "Match the language of the initial user prompt" in prompt
+    assert "If the user specifies a response language" in prompt
     assert "Format the whole response using Markdown" in prompt
 
     lightweight_prompt = pipe._build_lightweight_prompt(
@@ -48,4 +49,5 @@ def test_action_prompt_enforces_language_and_markdown() -> None:
     )
 
     assert "LANGUAGE CONSISTENCY" in lightweight_prompt
+    assert "Match the language of the initial user prompt" in lightweight_prompt
     assert "Markdown" in lightweight_prompt

--- a/tests/test_final_design_review_summary.py
+++ b/tests/test_final_design_review_summary.py
@@ -78,9 +78,20 @@ def test_final_review_appends_global_summary() -> None:
 
     assert "Section 1 : Résumé rapide" in global_section
     section1_content = global_section.split("Section 2 :", maxsplit=1)[0]
-    assert "Travail très abouti" in section1_content
-    assert "Compléter les tests unitaires" in section1_content
-    assert "rapport détaillé" in section1_content
+    summary_lines = [
+        line.strip()
+        for line in section1_content.splitlines()
+        if line.strip().startswith("-")
+    ]
+    assert any("Portée" in line for line in summary_lines)
+    assert any(
+        "Livrables traités" in line
+        and "Étape 1 – Analyse initiale" in line
+        and "Étape 2 – Prototype fonctionnel" in line
+        for line in summary_lines
+    )
+    assert any("Points forts" in line for line in summary_lines)
+    assert any("Axes de vigilance" in line for line in summary_lines)
 
     table_header = "| Étape | Score | Points forts | Axes d'amélioration |"
     assert table_header in global_section
@@ -98,20 +109,16 @@ def test_final_review_appends_global_summary() -> None:
         step_label = cells[0]
         assert step_label.startswith("Étape ")
         assert "–" in step_label
-        summary_words = step_label.split("–", maxsplit=1)[1].strip().split()
-        assert 1 <= len(summary_words) <= 4
+        summary_text = step_label.split("–", maxsplit=1)[1].strip()
+        summary_words = summary_text.split()
+        assert 2 <= len(summary_words) <= 6
+        assert summary_words[-1].lower() not in {"un", "une", "des", "pour", "avec"}
         score_cell = cells[1]
         assert score_cell.replace(",", ".").replace(" ", "").startswith("0.") or score_cell in {"0,60", "0,90"}
-        assert (
-            "Travail très abouti" in cells[2]
-            or "Résultat partiel" in cells[2]
-            or "rapport détaillé" in cells[2]
-        )
-        assert (
-            "Vérifier la cohérence" in cells[3]
-            or "Compléter les tests unitaires" in cells[3]
-            or "Tests manquants" in cells[3]
-        )
+        assert "Contenu :" not in cells[2]
+        assert "Contenu :" not in cells[3]
+        assert "rapport détaillé" not in cells[2]
+        assert "rapport détaillé" not in cells[3]
 
     assert "Section 3 : Prochaines étapes prioritaires" in global_section
     section3_content = global_section.split("Section 3 : Prochaines étapes prioritaires", maxsplit=1)[
@@ -121,6 +128,7 @@ def test_final_review_appends_global_summary() -> None:
     assert section3_lines[0].startswith("Analyse globale"), (
         "La section 3 doit commencer par une analyse globale du contenu."
     )
-    assert "prototype fonctionnel" in section3_lines[0]
+    assert "Objectif" in section3_lines[0]
+    assert "Analyse initiale" in section3_lines[0]
     next_steps_lines = [line for line in section3_lines if line.strip().startswith("- Étape")]
     assert next_steps_lines, "Les prochaines étapes doivent être listées sous forme de puces."

--- a/tests/test_step_short_label.py
+++ b/tests/test_step_short_label.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from planner import _build_step_short_label
+
+
+def test_short_label_focuses_on_prompt_subject() -> None:
+    description = (
+        "Rédiger un prompt pour un mammifère spécifique, en mentionnant des caractéristiques"
+        " détaillées comme l'environnement et le style artistique."
+    )
+    assert _build_step_short_label(description) == "Prompt mammifère spécifique"
+
+
+def test_short_label_trims_trailing_stopwords() -> None:
+    description = "Create a prompt for a tropical bird with rainforest context and lighting."
+    assert _build_step_short_label(description) == "Prompt tropical bird"


### PR DESCRIPTION
## Summary
- refine step label generation to focus on meaningful subjects and prevent truncated titles in design review tables
- add explicit language and Markdown guidance to action prompts while restructuring design review summaries and global analysis for clarity
- add regression tests covering short-label heuristics, prompt guidance, and the refreshed design review summary expectations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e51991846c8327a3e2a9761ac0e3d0